### PR TITLE
Relative url compare is not right

### DIFF
--- a/import.js
+++ b/import.js
@@ -119,6 +119,8 @@
 
   function searchExists (type, url) {
     var attr = srcByType(type), list = document.getElementsByTagName(tagByType(type));
+    if (url.indexOf('://') == -1)
+      url = window.location.protocol + '//' + window.location.host + url
     for (var i=0; i<list.length; i++) {
       if (list[i][attr] == url) return list[i];
     }


### PR DESCRIPTION
The href value from link tag will include  the protocal and domain, so that the compare will be not right. So I add them if the url is relative path.
